### PR TITLE
Add Dependabot Configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
Add a [Dependabot](https://docs.github.com/en/code-security/dependabot) configuration for checking a new version of GitHub Actions. It resolves #5.